### PR TITLE
Enable contact form via Formspree

### DIFF
--- a/forms/Readme.txt
+++ b/forms/Readme.txt
@@ -1,4 +1,11 @@
-The original template included a PHP/AJAX contact form that requires a proprietary library.
-This repository does not ship that library, so the contact form functionality is disabled.
+This site uses [Formspree](https://formspree.io) to process the contact form.
 
-You can still reach me by using the email address shown on the website.
+Steps to activate the form:
+1. Create a free account on Formspree and create a new form.
+2. Copy the form ID provided by Formspree (e.g. `https://formspree.io/f/abcde123`).
+3. Edit `forms/contact.php` and replace `your-form-id` with your actual ID.
+4. Optionally adjust the recipient email settings inside your Formspree dashboard.
+
+When the form is submitted, `forms/contact.php` forwards the request to your
+Formspree endpoint and returns `OK` on success so the front-end script can show
+the "sent" message.

--- a/forms/contact.php
+++ b/forms/contact.php
@@ -1,41 +1,27 @@
 <?php
-  /**
-  * Requires the "PHP Email Form" library
-  * The "PHP Email Form" library is available only in the pro version of the template
-  * The library should be uploaded to: vendor/php-email-form/php-email-form.php
-  * For more info and help: https://bootstrapmade.com/php-email-form/
-  */
+// Proxy script to forward contact form submissions to Formspree
+// Replace 'your-form-id' with your actual Formspree form ID
+$formspree_endpoint = 'https://formspree.io/f/your-form-id';
 
-  // Replace contact@example.com with your real receiving email address
-  $receiving_email_address = 'contact@example.com';
+$data = [
+  'name'    => $_POST['name'] ?? '',
+  'email'   => $_POST['email'] ?? '',
+  'subject' => $_POST['subject'] ?? '',
+  'message' => $_POST['message'] ?? ''
+];
 
-  if( file_exists($php_email_form = '../assets/vendor/php-email-form/php-email-form.php' )) {
-    include( $php_email_form );
-  } else {
-    die( 'Unable to load the "PHP Email Form" Library!');
-  }
+$ch = curl_init($formspree_endpoint);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_POST, true);
+curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($data));
+$response = curl_exec($ch);
+$httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+curl_close($ch);
 
-  $contact = new PHP_Email_Form;
-  $contact->ajax = true;
-  
-  $contact->to = $receiving_email_address;
-  $contact->from_name = $_POST['name'];
-  $contact->from_email = $_POST['email'];
-  $contact->subject = $_POST['subject'];
-
-  // Uncomment below code if you want to use SMTP to send emails. You need to enter your correct SMTP credentials
-  /*
-  $contact->smtp = array(
-    'host' => 'example.com',
-    'username' => 'example',
-    'password' => 'pass',
-    'port' => '587'
-  );
-  */
-
-  $contact->add_message( $_POST['name'], 'From');
-  $contact->add_message( $_POST['email'], 'Email');
-  $contact->add_message( $_POST['message'], 'Message', 10);
-
-  echo $contact->send();
+if ($httpCode >= 200 && $httpCode < 300) {
+  echo 'OK';
+} else {
+  http_response_code($httpCode);
+  echo 'Error';
+}
 ?>

--- a/index.html
+++ b/index.html
@@ -505,8 +505,7 @@
 
         <div class="section-title">
           <h2>Contact</h2>
-          <p>If you wish to contact me regarding collaborations, projects or other subjects, please get in touch with me using the following information:</p>
-          <p><em>Note: The contact form has been disabled. Please use the email address below to reach me.</em></p>
+          <p>If you wish to contact me regarding collaborations, projects or other subjects, please use the form below or the contact details.</p>
         </div>
 
         <div class="row" data-aos="fade-in">
@@ -533,8 +532,40 @@
             </div>
 
           </div>
-          <div class="col-lg-6 d-flex align-items-stretch"><div class="info">
-            <iframe src="https://maps.google.com/maps?q=IEETA,&t=&z=13&ie=UTF8&iwloc=&output=embed" frameborder="0" style="border:0; width: 100%; height: 290px;" allowfullscreen></iframe>
+          <div class="col-lg-6 mt-5 mt-lg-0 d-flex align-items-stretch">
+            <form action="forms/contact.php" method="post" role="form" class="php-email-form">
+              <div class="row">
+                <div class="form-group col-md-6">
+                  <label for="name">Your Name</label>
+                  <input type="text" name="name" class="form-control" id="name" required>
+                </div>
+                <div class="form-group col-md-6">
+                  <label for="email">Your Email</label>
+                  <input type="email" class="form-control" name="email" id="email" required>
+                </div>
+              </div>
+              <div class="form-group">
+                <label for="subject">Subject</label>
+                <input type="text" class="form-control" name="subject" id="subject" required>
+              </div>
+              <div class="form-group">
+                <label for="message">Message</label>
+                <textarea class="form-control" name="message" rows="10" required></textarea>
+              </div>
+              <div class="my-3">
+                <div class="loading">Loading</div>
+                <div class="error-message"></div>
+                <div class="sent-message">Your message has been sent. Thank you!</div>
+              </div>
+              <div class="text-center"><button type="submit">Send Message</button></div>
+            </form>
+          </div>
+        </div>
+
+        <div class="row mt-4" data-aos="fade-in">
+          <div class="col-lg-12">
+            <div class="info">
+              <iframe src="https://maps.google.com/maps?q=IEETA,&t=&z=13&ie=UTF8&iwloc=&output=embed" frameborder="0" style="border:0; width: 100%; height: 290px;" allowfullscreen></iframe>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add actual contact form HTML replacing the disabled message
- provide Formspree proxy script in `forms/contact.php`
- document how to set up the form service

## Testing
- `git status --short`