### PR TITLE
Improve dark mode text colors

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1317,17 +1317,18 @@ body.dark-mode .pub-link-icon {
 /* Dark mode improvements */
 body.dark-mode .skills .progress .skill,
 body.dark-mode .skills .progress .skill .val {
-  color: #e0e0e0;
+  color: #e0e0e0 !important;
 }
 
 body.dark-mode .altmetric-embed,
 body.dark-mode .altmetric-embed * {
   color: #e0e0e0 !important;
+  fill: #e0e0e0 !important;
 }
 
 body.dark-mode .altmetric-embed img {
   /* brighten badge and invert slightly so score pops */
-  filter: brightness(1.4) invert(0.2) contrast(1.2);
+  filter: brightness(1.6) invert(0.1) contrast(1.3);
 }
 
 /* Dark mode contact section */


### PR DESCRIPTION
## Summary
- ensure skill text colors stay light in dark mode
- adjust altmetric badge colours for better contrast

## Testing
- `git diff --check`
