### PR TITLE
Exclude backup files from Jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -20,6 +20,8 @@ exclude:
   - vendor/cache/
   - vendor/gems/
   - vendor/ruby/
+  - federated-learning-main.md
+  - "*-backup.md"
 
 # Default layout for pages
 defaults:


### PR DESCRIPTION
## Summary
- stop Jekyll from processing `federated-learning-main.md`
- skip all `*-backup.md` files via glob in `_config.yml`

## Testing
- `bundle exec jekyll build` *(fails: Could not locate Gemfile or .bundle/ directory)*
- `jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68909ad7326083279da2f7974a709fa6