### PR TITLE
Fix YAML front matter for federated learning pages

### DIFF
--- a/federated-learning-main.md
+++ b/federated-learning-main.md
@@ -40,7 +40,8 @@ last_updated_on: 2025-08-10
 aliases: ["federated_learning", "federated-learning"]
 icon: ti-cloud
 status: in_review
-has_children: truedmponline_template: "ELIXIR-CONVERGE-federated-study-preset"
+has_children: true
+dmponline_template: "ELIXIR-CONVERGE-federated-study-preset"
 training:
   - name: Federated Learning for Health Data Tutorial
     description: Hands-on tutorial for FL in health data contexts

--- a/federated-learning.md
+++ b/federated-learning.md
@@ -40,7 +40,8 @@ last_updated_on: 2025-08-10
 aliases: ["federated_learning", "federated-learning"]
 icon: ti-cloud
 status: in_review
-has_children: truedmponline_template: "ELIXIR-CONVERGE-federated-study-preset"
+has_children: true
+dmponline_template: "ELIXIR-CONVERGE-federated-study-preset"
 training:
   - name: Federated Learning for Health Data Tutorial
     description: Hands-on tutorial for FL in health data contexts


### PR DESCRIPTION
## Summary
- correct front matter in federated-learning pages by splitting `has_children` and `dmponline_template` into separate keys

## Testing
- `ruby -ryaml -rdate -e 'ARGV.each do |f| content=File.read(f); front=content.split(/^---\n/)[1].split(/\n---/)[0]; begin; YAML.safe_load(front, permitted_classes: [Date]); puts "#{f}: OK"; rescue => e; puts "#{f}: ERROR #{e}"; end; end' federated-learning.md federated-learning-main.md`

------
https://chatgpt.com/codex/tasks/task_e_6890a00c95948327a34523e0a039a1f2