### PR TITLE
Add figure include for captioned images

### DIFF
--- a/_includes/figure.html
+++ b/_includes/figure.html
@@ -1,0 +1,6 @@
+<figure>
+  <img src="{{ path | relative_url }}" alt="{{ alt }}">
+  {% if caption %}
+  <figcaption>{{ caption }}</figcaption>
+  {% endif %}
+</figure>


### PR DESCRIPTION
## Summary
- add reusable `figure.html` include to render images with captions

## Testing
- `jekyll build` *(fails: command not found)*
- `gem install jekyll` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6890a46fdc1c8327a6d3721d0d0fa500